### PR TITLE
Load and benchmark SuiteSparse matrices

### DIFF
--- a/example/wiki/sparse/KokkosSparse_nga_bspmv.cpp
+++ b/example/wiki/sparse/KokkosSparse_nga_bspmv.cpp
@@ -565,7 +565,7 @@ std::chrono::duration<double> measure(const mtx_t &myMatrix, const Scalar alpha,
 }
 
 template<typename bmtx_t>
-std::chrono::duration<double> measureBlock(const bmtx_t &myBlockMatrix, const std::vector<Ordinal> &val_entries_ptr, const Scalar alpha, const Scalar beta, const int repeat) {
+std::chrono::duration<double> measure_block(const bmtx_t &myBlockMatrix, const std::vector<Ordinal> &val_entries_ptr, const Scalar alpha, const Scalar beta, const int repeat) {
   auto const numRows = myBlockMatrix.numRows() * myBlockMatrix.blockDim();
   auto const x = make_lhs(numRows);
   typename values_type::non_const_type y("rhs", numRows);
@@ -580,7 +580,7 @@ std::chrono::duration<double> measureBlock(const bmtx_t &myBlockMatrix, const st
 }
 
 template<typename mtx_t>
-std::vector<Ordinal> buildEntryValuePointers(const mtx_t &myBlockMatrix) {
+std::vector<Ordinal> build_entry_ptr(const mtx_t &myBlockMatrix) {
   // Build pointer to entry values
   const Ordinal blockSize = myBlockMatrix.blockDim();
   const Ordinal numBlocks = myBlockMatrix.numRows();
@@ -702,7 +702,7 @@ bcrs_matrix_t_ to_block_crs_matrix(const crs_matrix_t_& mat_crs,
 }
 
 template<typename mtx_t>
-void testMatrix(const mtx_t &myMatrix, const int blockSize, const int repeat) {
+void test_matrix(const mtx_t &myMatrix, const int blockSize, const int repeat) {
 
   const Scalar alpha = details::SC_ONE;
   const Scalar beta  = details::SC_ZERO;
@@ -721,7 +721,7 @@ void testMatrix(const mtx_t &myMatrix, const int blockSize, const int repeat) {
   //
   bcrs_matrix_t_ myBlockMatrix = to_block_crs_matrix(myMatrix, blockSize);
 
-  auto const val_entries_ptr = buildEntryValuePointers(myBlockMatrix);
+  auto const val_entries_ptr = build_entry_ptr(myBlockMatrix);
 
   double error = 0.0, maxNorm = 0.0;
   compare(myMatrix, myBlockMatrix, val_entries_ptr, alpha, beta, error, maxNorm);
@@ -732,7 +732,7 @@ void testMatrix(const mtx_t &myMatrix, const int blockSize, const int repeat) {
   //
   // Test speed of Mat-Vec product
   //
-  std::chrono::duration<double> dt_bcrs = measureBlock(myBlockMatrix, val_entries_ptr, alpha, beta, repeat);
+  std::chrono::duration<double> dt_bcrs = measure_block(myBlockMatrix, val_entries_ptr, alpha, beta, repeat);
 
   std::cout << " Total time for BlockCrs Mat-Vec " << dt_bcrs.count()
             << " Avg. " << dt_bcrs.count() / static_cast<double>(repeat);
@@ -751,7 +751,7 @@ void testMatrix(const mtx_t &myMatrix, const int blockSize, const int repeat) {
   std::cout << " ======================== \n";
 }
 
-int testRandom(const int repeat = 7500, const int minBlockSize = 1, const int maxBlockSize = 12) {
+int test_random(const int repeat = 7500, const int minBlockSize = 1, const int maxBlockSize = 12) {
     int return_value = 0;
 
     // The mat_structure view is used to generate a matrix using
@@ -784,13 +784,13 @@ int testRandom(const int repeat = 7500, const int minBlockSize = 1, const int ma
       std::cout << " Matrix Size " << myMatrix.numRows() << " nnz " << myMatrix.nnz()
                 << "\n";
 
-      testMatrix(myMatrix, blockSize, repeat);
+      test_matrix(myMatrix, blockSize, repeat);
 
     }
     return return_value;
 }
 
-int testSamples(const int repeat = 3000) {
+int test_samples(const int repeat = 3000) {
   int return_value = 0;
 
   srand(17312837);
@@ -815,7 +815,7 @@ int testSamples(const int repeat = 3000) {
     std::cout << " Matrix Size " << myMatrix.numCols() << " x " << myMatrix.numRows() << ", nnz " << myMatrix.nnz()
               << "\n";
 
-    testMatrix(myMatrix, blockSize, repeat);
+    test_matrix(myMatrix, blockSize, repeat);
 
   });
   return return_value;
@@ -830,9 +830,9 @@ int main() {
   Kokkos::initialize();
 
 #ifdef TEST_RANDOM_BSPMV
-  int return_value = details::testRandom();
+  int return_value = details::test_random();
 #else
-  int return_value = details::testSamples();
+  int return_value = details::test_samples();
 #endif
 
   Kokkos::finalize();

--- a/example/wiki/sparse/KokkosSparse_nga_bspmv.cpp
+++ b/example/wiki/sparse/KokkosSparse_nga_bspmv.cpp
@@ -702,6 +702,37 @@ int testRandom(const int repeat = 7500, const int minBlockSize = 1, const int ma
     return return_value;
 }
 
+int testSamples(const int repeat = 3000) {
+  int return_value = 0;
+
+  srand(17312837);
+
+  const std::vector<std::tuple<const char*, int> > SAMPLES{ // std::tuple(char* fileName, int blockSize)
+    std::make_tuple("GT01R.mtx", 5), // ID:2335	Fluorem	GT01R	7980	7980	430909	1	0	1	0	0.8811455350661695	9.457852263618717e-06	computational fluid dynamics problem	430909
+    std::make_tuple("raefsky4.mtx", 3), // ID:817	Simon	raefsky4	19779	19779	1316789	1	0	1	1	1	1	structural problem	1328611
+    std::make_tuple("bmw7st_1.mtx", 6), // ID:1253	GHS_psdef	bmw7st_1	141347	141347	7318399	1	0	1	1	1	1	structural problem	7339667
+    std::make_tuple("pwtk.mtx", 6), // ID:369	Boeing	pwtk	217918	217918	11524432	1	0	1	1	1	1	structural problem	11634424
+    std::make_tuple("RM07R.mtx", 7), // ID:2337	Fluorem	RM07R	381689	381689	37464962	1	0	1	0	0.9261667922354103	4.260681089287885e-06	computational fluid dynamics problem	37464962
+    std::make_tuple("audikw_1.mtx", 3) // ID:1252 GHS_psdef	audikw_1	943695	943695	77651847	1	0	1	1	1	1	structural problem	77651847
+  };
+
+  // Loop over sample matrix files
+  std::for_each(SAMPLES.begin(), SAMPLES.end(), [=](auto const& sample) {
+    const char* fileName = std::get<0>(sample);
+    const int blockSize = std::get<1>(sample);
+    crs_matrix_t_ myMatrix = KokkosKernels::Impl::read_kokkos_crst_matrix<crs_matrix_t_>(fileName);
+
+    std::cout << " ======================== \n";
+    std::cout << " Sample: '" << fileName << "', Block Size " << blockSize;
+    std::cout << " Matrix Size " << myMatrix.numCols() << " x " << myMatrix.numRows() << ", nnz " << myMatrix.nnz()
+              << "\n";
+
+    testMatrix(myMatrix, blockSize, repeat);
+
+  });
+  return return_value;
+}
+
 } // namespace details
 
 //#define TEST_RANDOM_BSPMV
@@ -710,7 +741,11 @@ int main() {
 
   Kokkos::initialize();
 
+#ifdef TEST_RANDOM_BSPMV
   int return_value = details::testRandom();
+#else
+  int return_value = details::testSamples();
+#endif
 
   Kokkos::finalize();
 


### PR DESCRIPTION
Fixes #5 

- [x] Implement test routine that times and compares our block `spmv()` with regular `KokkosSparse::spmv()` on [selected](https://github.com/fnrizzi/kokkos-kernels/issues/3#issuecomment-842759224) matrices from [SSMC samples](https://sparse.tamu.edu).
- [ ] Benchmark average timings and flops per second with 3000 repetitions on _Serial_, _OpenMP_ and _CUDA_ (see [1366653.pdf](https://github.com/fnrizzi/kokkos-kernels/files/6497757/1366653.pdf)).

| File | Block size | ID | info |
|---|---|---|---|
|  GT01R.mtx | 5 | 2335 | Fluorem/GT01R 7980x7980 nnz=430909 computational fluid dynamics problem |
| raefsky4.mtx | 3 | 817 | Simon/raefsky4 19779x19779 nnz=1316789 structural problem |
| bmw7st_1.mtx | 6 | 1253 | GHS_psdef/bmw7st_1 141347x141347 nnz=7318399 structural problem |
| pwtk.mtx | 6 | 369 | Boeing/pwtk 217918x217918 nnz=11524432 structural problem |
| RM07R.mtx | 7 | 2337 | Fluorem/RM07R 381689x381689 nnz=37464962 computational fluid dynamics problem |
| audikw_1.mtx | 3 | 1252 | GHS_psdef/audikw_1 943695x943695 nnz=77651847 structural problem |
