### PR TITLE
#9 Test refactoring

### DIFF
--- a/example/wiki/sparse/KokkosSparse_nga_bspmv.cpp
+++ b/example/wiki/sparse/KokkosSparse_nga_bspmv.cpp
@@ -481,9 +481,9 @@ int test_samples(const int repeat = 3000) {
       // 7980	7980	430909	1	0
       // 1	0	0.8811455350661695	9.457852263618717e-06
       // computational fluid dynamics problem	430909
-      ,
-      std::make_tuple("raefsky4.mtx",
-                      3)  // ID:817	Simon	raefsky4	19779
+      //,
+      //std::make_tuple("raefsky4.mtx",
+      //                3)  // ID:817	Simon	raefsky4	19779
       // 19779	1316789	1	0	1	1	1
       // 1	structural problem	1328611
       //    , std::make_tuple("bmw7st_1.mtx", 6) // ID:1253	GHS_psdef
@@ -495,9 +495,9 @@ int test_samples(const int repeat = 3000) {
       //    1
       //    structural
       //    problem	11634424
-      ,
-      std::make_tuple("RM07R.mtx",
-                      7)  // ID:2337	Fluorem	RM07R	381689	381689 37464962
+      //,
+      //std::make_tuple("RM07R.mtx",
+      //                7)  // ID:2337	Fluorem	RM07R	381689	381689 37464962
       // 1	0	1	0
       // 0.9261667922354103	4.260681089287885e-06
       // computational fluid dynamics problem	37464962
@@ -528,7 +528,7 @@ int test_samples(const int repeat = 3000) {
 
 }  // namespace details
 
-#define TEST_RANDOM_BSPMV
+//#define TEST_RANDOM_BSPMV
 
 int main() {
   Kokkos::initialize();

--- a/example/wiki/sparse/KokkosSparse_nga_bspmv.cpp
+++ b/example/wiki/sparse/KokkosSparse_nga_bspmv.cpp
@@ -534,6 +534,10 @@ int main() {
     std::vector<test_t::RunInfo> variants;
     variants.push_back({"N"});
     variants.push_back({"T"});
+    variants.push_back({"N", -1, -1.0});
+    variants.push_back({"T", 3.14159, 0.25});
+    variants.push_back({"N", 0.0, 0.0});
+    variants.push_back({"N", 0.0, 1.0});
 
     // Run samples
     int sample_id = 0;


### PR DESCRIPTION
Part of #9

* Running all samples: random and market matrices.
* Running multiple mode/alpha/beta variants for each sample.
* Table/CSV output for easy spreadsheet processing.

Sample output:
```csv
no.	name	size	block	nnz	mode	alpha	beta	error	maxNorm	crsTime	crsAvg	crsGFlops	bcrsTime	bcrsAvg	bcrsGFlops	ratio	remarks
1:1/3	rand-10	415520	10	20694400	N	1	0	0	21.5914	8.84966	0.00864225	2.39456	7.27528	0.00710477	2.91275	0.822098	good
1:2/3	^	^	^	^	T	1	0	1.42109e-14	20.5859	15.6083	0.0152425	1.35768	15.7031	0.015335	1.34948	1.00607	NOT_faster
1:3/3	^	^	^	^	N	-1	-1	0	20.1678	8.91246	0.00870358	2.37769	7.38538	0.00721229	2.86932	0.828658	good
1:4/3	^	^	^	^	T	3.14159	0.25	5.68434e-14	62.8597	14.7627	0.0144167	1.43545	15.2628	0.0149051	1.38841	1.03388	NOT_faster
1:5/3	^	^	^	^	N	0	0	0	0	0.0243548	2.3784e-05	870.098	0.0182034	1.77768e-05	1164.13	0.747426	good
1:6/3	^	^	^	^	N	0	1	0	0	0.124868	0.000121942	169.707	0.120228	0.00011741	176.257	0.962838	good
2:1/3	rand-12	498624	12	29799936	N	1	0	0	23.4407	12.6426	0.0123462	2.41368	9.88527	0.00965358	3.08693	0.781904	good
2:2/3	^	^	^	^	T	1	0	2.13163e-14	25.2746	21.667	0.0211592	1.40837	22.2227	0.0217019	1.37315	1.02565	NOT_faster
2:3/3	^	^	^	^	N	-1	-1	0	24.0409	13.365	0.0130518	2.28321	10.0778	0.00984157	3.02797	0.754041	good
2:4/3	^	^	^	^	T	3.14159	0.25	5.68434e-14	74.2295	21.2639	0.0207655	1.43507	21.4885	0.0209848	1.42007	1.01056	NOT_faster
2:5/3	^	^	^	^	N	0	0	0	0	0.0210595	2.05659e-05	1449	0.0429506	4.19439e-05	710.471	2.03949	NOT_faster
2:6/3	^	^	^	^	N	0	1	0	0	0.148766	0.00014528	205.121	0.145052	0.000141652	210.374	0.975029	good
3:1/3	GT01R.mtx	7980	5	430909	N	1	0	0	36366.2	0.12108	4.03601e-05	10.6766	0.0826729	2.75576e-05	15.6366	0.682794	good
3:2/3	^	^	^	^	T	1	0	1.45519e-11	54679	1.59771	0.000532572	0.80911	1.30716	0.000435721	0.988956	0.818145	good
3:3/3	^	^	^	^	N	-1	-1	0	75688.9	0.127964	4.26547e-05	10.1023	0.38661	0.00012887	3.34375	3.02124	NOT_faster
3:4/3	^	^	^	^	T	3.14159	0.25	9.45874e-11	147812	1.18387	0.000394623	1.09195	1.28176	0.000427253	1.00856	1.08269	NOT_faster
3:5/3	^	^	^	^	N	0	0	0	0	0.0184308	6.1436e-06	70.1395	0.0080156	2.67187e-06	161.276	0.434902	good
3:6/3	^	^	^	^	N	0	1	0	0	0.0071068	2.36893e-06	181.9	0.0069288	2.3096e-06	186.573	0.974954	good
```