### PR TITLE
#9 Refactoring of explicit expansion for small block size

### DIFF
--- a/src/sparse/KokkosSparse_spmv.hpp
+++ b/src/sparse/KokkosSparse_spmv.hpp
@@ -537,19 +537,23 @@ void spmv(KokkosKernels::Experimental::Controls controls, const char mode[],
 #endif
   //
   if (X.extent(1) == 1) {
-    if (mode[0] == KokkosSparse::NoTranspose[0]) {
-      return Impl::spMatVec_no_transpose(controls, alpha, A, X, beta, Y, useFallback);
-    } else if (mode[0] == KokkosSparse::Transpose[0]) {
-      return Impl::spMatVec_transpose(controls, alpha, A, X, beta, Y, useFallback);
+    if ((mode[0] == KokkosSparse::NoTranspose[0]) || (mode[0] == KokkosSparse::Conjugate[0])) {
+      bool useConjugate = (mode[0] == KokkosSparse::Conjugate[0]);
+      return Impl::spMatVec_no_transpose(controls, alpha, A, X, beta, Y, useFallback, useConjugate);
+    } else if ((mode[0] == KokkosSparse::Transpose[0]) || (mode[0] == KokkosSparse::ConjugateTranspose[0])) {
+      bool useConjugate = (mode[0] == KokkosSparse::ConjugateTranspose[0]);
+      return Impl::spMatVec_transpose(controls, alpha, A, X, beta, Y, useFallback, useConjugate);
     }
   } else {
-    if (mode[0] == KokkosSparse::NoTranspose[0]) {
+    if ((mode[0] == KokkosSparse::NoTranspose[0]) || (mode[0] == KokkosSparse::Conjugate[0])) {
+      bool useConjugate = (mode[0] == KokkosSparse::Conjugate[0]);
       std::cerr
           << "\n !!! Sparse Mat - MultiVec product not implemented !!!\n\n";
       //      return Impl::spMatMultiVec_no_transpose(controls, alpha, A, X, beta, Y,
       //      useFallback);
       exit(-11);
-    } else if (mode[0] == KokkosSparse::Transpose[0]) {
+    } else if ((mode[0] == KokkosSparse::Transpose[0]) || (mode[0] == KokkosSparse::ConjugateTranspose[0])) {
+      bool useConjugate = (mode[0] == KokkosSparse::ConjugateTranspose[0]);
       std::cerr
           << "\n !!! Sparse Mat - MultiVec product not implemented !!!\n\n";
       //      return Impl::spMatMultiVec_transpose(controls, alpha, A, X, beta, Y,


### PR DESCRIPTION
Refs #9 
Based on issue #17

Refactored explicit expansion for serial block `smpv`, based on reusable `Utils::eti_expand()` uitility.